### PR TITLE
Tokenize spaces when explicitly requested and reduce iterations in occurrence counting loop

### DIFF
--- a/src/classifier.js
+++ b/src/classifier.js
@@ -68,7 +68,7 @@ class Classifier {
                 tokens = this.vectorize(tokens)
             }
 
-            // Set up an empty entry for the label if it does not exist 
+            // Set up an empty entry for the label if it does not exist
             if (typeof this._model.data[label] === 'undefined') {
                 this._model.data[label] = {}
             }
@@ -148,7 +148,7 @@ class Classifier {
 
     /**
      * Split a string into an array of lowercase words, with all non-letter characters removed
-     * 
+     *
      * @param {string} input
      * @return {Array}
      */
@@ -179,7 +179,7 @@ class Classifier {
         if (!(words instanceof Array)) {
             throw new Error('input must be either a string or Array')
         }
-        
+
         if (this._model.nGramMax < this._model.nGramMin) {
             throw new Error('Invalid nGramMin/nGramMax combination in model config')
         }
@@ -190,22 +190,28 @@ class Classifier {
         // based on the models configured min/max values
         words.forEach((word, index) => {
             let sequence = ''
+            let tokenCount = 0
+            let nextWord
 
-            words.slice(index).forEach(nextWord => {
+            // Create n-gram(s) of between nGramMin and nGramMax words from segment starting at (index)
+            // Increment the occurrence counter (tokens[sequence]) for each n-gram created
+            // Stop looping once we have nGramMax words (or reach the end of the segment)
+            let segment = words.slice(index)
+            while (tokenCount < this._model.nGramMax && tokenCount < segment.length) {
+                nextWord = segment[tokenCount]
                 sequence += sequence ? (' ' + nextWord) : nextWord
-                let tokenCount = sequence.split(' ').length
+                tokenCount++
+                if(tokenCount >= this._model.nGramMin && tokenCount <= this._model.nGramMax) {
+                    if (typeof tokens[sequence] === 'undefined') {
+                        tokens[sequence] = 0
+                    }
 
-                if (tokenCount < this._model.nGramMin || tokenCount > this._model.nGramMax) {
-                    return
+                    ++tokens[sequence]
                 }
-
-                if (typeof tokens[sequence] === 'undefined') {
-                    tokens[sequence] = 0
-                }
-
-                ++tokens[sequence]
-            })
+            }
         })
+
+
 
         return tokens
     }

--- a/test/classifier.js
+++ b/test/classifier.js
@@ -74,7 +74,7 @@ describe('Classifier', () => {
             const classifier = new Classifier()
 
             classifier.model.nGramMin = 2
-            
+
             expect(() => classifier.tokenize('Hello world!')).to.throw(Error)
         })
 
@@ -126,6 +126,16 @@ describe('Classifier', () => {
                 'hello': 1,
                 'hello world': 1,
                 'world': 1
+            })
+        })
+
+        it('should create a unigrams for the space character from an array of characters including a space', () => {
+            const classifier = new Classifier()
+
+            expect(classifier.tokenize([' ','a','b'])).to.eql({
+                ' ': 1,
+                'a': 1,
+                'b': 1
             })
         })
 
@@ -195,7 +205,7 @@ describe('Classifier', () => {
 
             expect(() => classifier.train('test', [])).to.throw(Error)
         })
-        
+
         it('should add tokens to the vocabulary (if not configured to false)', () => {
             const classifier = new Classifier()
 
@@ -254,7 +264,7 @@ describe('Classifier', () => {
             expect(classifier.train('hello world', 'test')).to.equal(classifier)
         })
     })
-    
+
     describe('cosineSimilarity', () => {
         it('should throw an error if v1 is not an object literal', () => {
             const classifier = new Classifier()


### PR DESCRIPTION
The original `tokenize` method assembled a `sequence` of words using the space character as a delimiter, then counted tokens using `split()` on the space character. This fails if there are spaces in the words passed to the tokenizer. This is not normally the case when used with a string or array of words, but in the case where you want to use single characters as your tokens, spaces should be supported. This allows cosine comparisons to be done on character arrays and ensures results match other cosine distance implementations.

The new test added demonstrates this (passes with this new code, fails with the original).

Additionally, the original loop that counts occurrences of each nGram looped through **all** words in every segment. This could be quite inefficient. This version stops looping once nGramMax tokens have been counted and is up to 10x faster when comparing arrays of around 100 words.